### PR TITLE
Add options struct constructors and typed helpers

### DIFF
--- a/docs/websocketmq-onboarding-guide.md
+++ b/docs/websocketmq-onboarding-guide.md
@@ -159,14 +159,17 @@ WebSocketMQ supports several communication patterns:
 
 1. **Create a Broker**:
    ```go
-   // Create a logger
    logger := yourLoggerImplementation
 
-   // Create broker options
+   // Start with defaults and tweak only what you need
    brokerOpts := broker.DefaultOptions()
-   
-   // Create the broker
-   b := ps.New(logger, brokerOpts)
+   brokerOpts.PingInterval = 15 * time.Second
+
+   // Create the broker using the options struct
+   b, err := broker.NewWithOptions(brokerOpts)
+   if err != nil {
+       log.Fatal(err)
+   }
    ```
 
 2. **Create a WebSocket Handler**:
@@ -218,6 +221,18 @@ WebSocketMQ supports several communication patterns:
    // Process the response
    // ...
    ```
+
+### Go Client Setup with Options
+
+```go
+clientOpts := client.DefaultOptions()
+clientOpts.AutoReconnect = true
+
+cli, err := client.ConnectWithOptions("ws://localhost:8080/wsmq", clientOpts)
+if err != nil {
+    log.Fatal(err)
+}
+```
 
 ### Client-Side Implementation
 
@@ -286,6 +301,22 @@ For client-side implementation, you'll typically use JavaScript in the browser. 
 - **Message Size**: Keep message size small to minimize network overhead
 - **Subscription Management**: Limit the number of subscriptions per client
 - **Connection Pooling**: Consider connection pooling for high-traffic applications
+
+### Typed Request Helpers
+
+The Go library includes helpers to enforce compile-time safety when working with RPC.
+Use `client.GenericRequest[T]` on the client and `broker.GenericClientRequest[T]`
+on the server to automatically unmarshal responses:
+
+```go
+type TimeResp struct { CurrentTime string }
+
+resp, err := client.GenericRequest[TimeResp](cli, ctx, "time.now")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(resp.CurrentTime)
+```
 
 ## Advanced Topics
 

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -95,6 +95,33 @@ func WithPingInterval(interval time.Duration) Option {
 	}
 }
 
+// WithWriteTimeout sets the write timeout for sending messages to clients.
+func WithWriteTimeout(timeout time.Duration) Option {
+	return func(b *Broker) {
+		if timeout > 0 {
+			b.config.writeTimeout = timeout
+		}
+	}
+}
+
+// WithReadTimeout sets the read timeout for client connections.
+func WithReadTimeout(timeout time.Duration) Option {
+	return func(b *Broker) {
+		if timeout > 0 {
+			b.config.readTimeout = timeout
+		}
+	}
+}
+
+// WithServerRequestTimeout sets the timeout for server-initiated requests to clients.
+func WithServerRequestTimeout(timeout time.Duration) Option {
+	return func(b *Broker) {
+		if timeout > 0 {
+			b.config.serverRequestTimeout = timeout
+		}
+	}
+}
+
 // New creates a new Broker.
 func New(opts ...Option) (*Broker, error) {
 	mainCtx, mainCancel := context.WithCancel(context.Background())

--- a/pkg/broker/generic_client_request.go
+++ b/pkg/broker/generic_client_request.go
@@ -1,0 +1,12 @@
+package broker
+
+import "context"
+
+// GenericClientRequest sends a typed request to a client and decodes the response into type T.
+func GenericClientRequest[T any](ch ClientHandle, ctx context.Context, topic string, requestData interface{}, timeout time.Duration) (*T, error) {
+	var resp T
+	if err := ch.SendClientRequest(ctx, topic, requestData, &resp, timeout); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/pkg/broker/options.go
+++ b/pkg/broker/options.go
@@ -1,0 +1,48 @@
+package broker
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// Options contains configuration values for creating a Broker using NewWithOptions.
+type Options struct {
+	Logger               *slog.Logger
+	AcceptOptions        *websocket.AcceptOptions
+	ClientSendBuffer     int
+	WriteTimeout         time.Duration
+	ReadTimeout          time.Duration
+	PingInterval         time.Duration
+	ServerRequestTimeout time.Duration
+}
+
+// DefaultOptions returns an Options struct populated with library defaults.
+func DefaultOptions() Options {
+	return Options{
+		Logger:               slog.Default(),
+		AcceptOptions:        &websocket.AcceptOptions{},
+		ClientSendBuffer:     defaultClientSendBuffer,
+		WriteTimeout:         defaultWriteTimeout,
+		ReadTimeout:          defaultReadTimeout,
+		PingInterval:         libraryDefaultPingInterval,
+		ServerRequestTimeout: defaultServerRequestTimeout,
+	}
+}
+
+// NewWithOptions creates a new Broker using an Options struct.
+// Additional functional options may be supplied and will override values from the struct.
+func NewWithOptions(opts Options, extraOpts ...Option) (*Broker, error) {
+	optionFns := []Option{
+		WithLogger(opts.Logger),
+		WithAcceptOptions(opts.AcceptOptions),
+		WithClientSendBuffer(opts.ClientSendBuffer),
+		WithWriteTimeout(opts.WriteTimeout),
+		WithReadTimeout(opts.ReadTimeout),
+		WithPingInterval(opts.PingInterval),
+		WithServerRequestTimeout(opts.ServerRequestTimeout),
+	}
+	optionFns = append(optionFns, extraOpts...)
+	return New(optionFns...)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -160,6 +160,24 @@ func WithClientURL(url string) Option {
 	}
 }
 
+// WithWriteTimeout sets the write timeout for sending messages to the server.
+func WithWriteTimeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		if timeout > 0 {
+			c.config.writeTimeout = timeout
+		}
+	}
+}
+
+// WithReadTimeout sets the read timeout for responses from the server.
+func WithReadTimeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		if timeout > 0 {
+			c.config.readTimeout = timeout
+		}
+	}
+}
+
 // Connect establishes a WebSocket connection.
 func Connect(urlStr string, opts ...Option) (*Client, error) {
 	clientCtx, clientCancel := context.WithCancel(context.Background())

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// Options contains configuration values for ConnectWithOptions.
+type Options struct {
+	Logger                *slog.Logger
+	DialOptions           *websocket.DialOptions
+	DefaultRequestTimeout time.Duration
+	WriteTimeout          time.Duration
+	ReadTimeout           time.Duration
+	PingInterval          time.Duration
+	AutoReconnect         bool
+	ReconnectAttempts     int
+	ReconnectDelayMin     time.Duration
+	ReconnectDelayMax     time.Duration
+	ClientName            string
+	ClientType            string
+	ClientURL             string
+}
+
+// DefaultOptions returns a Options struct populated with library defaults.
+func DefaultOptions() Options {
+	return Options{
+		Logger:                slog.Default(),
+		DialOptions:           &websocket.DialOptions{HTTPClient: http.DefaultClient},
+		DefaultRequestTimeout: defaultClientReqTimeout,
+		WriteTimeout:          defaultWriteClientTimeout,
+		ReadTimeout:           defaultReadClientTimeout,
+		PingInterval:          libraryDefaultClientPingInterval,
+		AutoReconnect:         false,
+		ReconnectAttempts:     defaultReconnectAttempts,
+		ReconnectDelayMin:     defaultReconnectDelayMin,
+		ReconnectDelayMax:     defaultReconnectDelayMax,
+	}
+}
+
+// ConnectWithOptions establishes a connection using an Options struct.
+// Additional Option functions may be provided and override struct values.
+func ConnectWithOptions(urlStr string, optsStruct Options, extraOpts ...Option) (*Client, error) {
+	optionFns := []Option{
+		WithLogger(optsStruct.Logger),
+		WithDialOptions(optsStruct.DialOptions),
+		WithDefaultRequestTimeout(optsStruct.DefaultRequestTimeout),
+		WithWriteTimeout(optsStruct.WriteTimeout),
+		WithReadTimeout(optsStruct.ReadTimeout),
+		WithClientPingInterval(optsStruct.PingInterval),
+	}
+	if optsStruct.AutoReconnect {
+		optionFns = append(optionFns, WithAutoReconnect(optsStruct.ReconnectAttempts, optsStruct.ReconnectDelayMin, optsStruct.ReconnectDelayMax))
+	}
+	if optsStruct.ClientName != "" {
+		optionFns = append(optionFns, WithClientName(optsStruct.ClientName))
+	}
+	if optsStruct.ClientType != "" {
+		optionFns = append(optionFns, WithClientType(optsStruct.ClientType))
+	}
+	if optsStruct.ClientURL != "" {
+		optionFns = append(optionFns, WithClientURL(optsStruct.ClientURL))
+	}
+
+	optionFns = append(optionFns, extraOpts...)
+	return Connect(urlStr, optionFns...)
+}


### PR DESCRIPTION
## Summary
- add Options structs for broker and client with defaults
- expose new constructors using these option structs
- expose WithWriteTimeout, WithReadTimeout, and WithServerRequestTimeout options
- add GenericClientRequest helper for server-initiated RPC
- document option-based setup and typed request helpers in onboarding guide

## Testing
- `go test ./...` *(fails: proxyconnect tcp: no route to host)*