### PR TITLE
Add client-to-client proxy and discovery

### DIFF
--- a/docs/websocketmq-onboarding-guide.md
+++ b/docs/websocketmq-onboarding-guide.md
@@ -494,6 +494,14 @@ function setupHandlers() {
 client.connect();
 ```
 
+## Built-in Utility Topics
+
+WebSocketMQ exposes several system topics to help manage connected clients.
+
+- `system:proxy` &mdash; Forward a request from one client to another. The request body should include `targetId`, `topic`, and `payload` fields. The handler returns the response from the destination client.
+- `system:list_clients` &mdash; Retrieve details about currently connected clients. Include `clientType` in the request to filter by type.
+- `system:register` &mdash; Clients automatically send this when connecting and may resend it to update their metadata.
+
 ## Conclusion
 
 WebSocketMQ provides a robust foundation for building real-time, bidirectional communication between clients and servers. By following the patterns and practices outlined in this guide, you can implement reliable messaging systems for your applications.

--- a/pkg/shared_types/types.go
+++ b/pkg/shared_types/types.go
@@ -1,7 +1,10 @@
 // shared_types/types.go
 package shared_types
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Topic Constants - used by both client and server for routing.
 const (
@@ -13,7 +16,9 @@ const (
 	TopicSlowClientRequest = "client:slow_request" // Server sends to client, client is slow
 	TopicSlowServerRequest = "server:slow_request" // Client sends to server, server is slow
 	TopicBroadcastTest     = "test:broadcast"
-	TopicClientRegister    = "system:register" // Client registration
+	TopicClientRegister    = "system:register"     // Client registration
+	TopicProxyRequest      = "system:proxy"        // Client-to-client proxy request
+	TopicListClients       = "system:list_clients" // List connected clients
 )
 
 // --- Message Structs ---
@@ -107,4 +112,29 @@ type ClientRegistrationResponse struct {
 	ServerAssignedID string `json:"serverAssignedId"` // Server-generated ID that becomes the source of truth
 	ClientName       string `json:"clientName"`       // Confirmed or modified client name
 	ServerTime       string `json:"serverTime"`       // Server time for synchronization
+}
+
+// ProxyRequest describes a request from one client to another via the broker.
+type ProxyRequest struct {
+	TargetID string          `json:"targetId"`
+	Topic    string          `json:"topic"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+// ClientSummary contains basic information about a connected client.
+type ClientSummary struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	ClientType string `json:"clientType"`
+	ClientURL  string `json:"clientUrl"`
+}
+
+// ListClientsRequest allows filtering when listing connected clients.
+type ListClientsRequest struct {
+	ClientType string `json:"clientType,omitempty"`
+}
+
+// ListClientsResponse returns information about currently connected clients.
+type ListClientsResponse struct {
+	Clients []ClientSummary `json:"clients"`
 }


### PR DESCRIPTION
## Summary
- enable client-to-client proxy requests through the broker
- expose session discovery via `system:list_clients`
- track client session IDs so they can be queried
- document utility topics in onboarding guide
- add tests for proxy and list features

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*